### PR TITLE
Correction sécurité : suppression des identifiants API en dur

### DIFF
--- a/MediaTekDocuments/App.config
+++ b/MediaTekDocuments/App.config
@@ -2,7 +2,10 @@
 <configuration>
     <configSections>
     </configSections>
-    <startup> 
+	<appSettings>
+		<add key="apiAuth" value="admin:adminpwd" />
+	</appSettings>
+	<startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
   <runtime>

--- a/MediaTekDocuments/dal/Access.cs
+++ b/MediaTekDocuments/dal/Access.cs
@@ -54,7 +54,11 @@ namespace MediaTekDocuments.dal
             String authenticationString;
             try
             {
-                authenticationString = "admin:adminpwd";
+                authenticationString = ConfigurationManager.AppSettings["apiAuth"];
+                if (string.IsNullOrEmpty(authenticationString))
+                {
+                    throw new Exception("Le paramètre apiAuth est absent du fichier App.config.");
+                }
                 api = ApiRest.GetInstance(uriApi, authenticationString);
             }
             catch (Exception e)


### PR DESCRIPTION
Problème :
Les identifiants d’accès à l’API étaient stockés en dur dans le code source.

Correction apportée :
- ajout de la clé apiAuth dans App.config
- lecture de cette valeur dans Access.cs via ConfigurationManager.AppSettings

Bénéfice :
- les identifiants ne sont plus écrits directement dans le code
- la configuration est plus facile à modifier
- la solution est plus sécurisée et plus maintenable
